### PR TITLE
Use try! to step

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -127,11 +127,7 @@ impl Machine {
                 return Ok(());
             }
 
-            let result = self.step();
-            match result {
-                Err(e) => return Err(e),
-                _ => ()
-            }
+            try!(self.step());
         }
     }
 }


### PR DESCRIPTION
I usually don't like macros, but try! is really handy.

It does two things:
* Destructures Ok(v)
* Destructures Err(e), converts it to the error
type returned by the function using FromError, and returns
immediately.

It's a really nice way of saying "don't continue if that fails".